### PR TITLE
Fix mtd resetbc

### DIFF
--- a/package/system/mtd/src/linksys_bootcount.c
+++ b/package/system/mtd/src/linksys_bootcount.c
@@ -69,12 +69,10 @@ struct bootcounter {
 	uint32_t checksum;
 };
 
-static char page[2048];
-
 int mtd_resetbc(const char *mtd)
 {
 	struct mtd_info_user mtd_info;
-	struct bootcounter *curr = (struct bootcounter *)page;
+	struct bootcounter *curr = NULL;
 	unsigned int i;
 	unsigned int bc_offset_increment;
 	int last_count = 0;
@@ -108,23 +106,22 @@ int mtd_resetbc(const char *mtd)
 	}
 
 	num_bc = mtd_info.size / bc_offset_increment;
+        curr = malloc(bc_offset_increment);
 
 	for (i = 0; i < num_bc; i++) {
-		pread(fd, curr, sizeof(*curr), i * bc_offset_increment);
+		pread(fd, curr, sizeof(struct bootcounter), i * bc_offset_increment);
 
 		/* Existing code assumes erase is to 0xff; left as-is (2019) */
+		if (curr->magic == 0xffffffff)
+			break;
 
-		if (curr->magic != BOOTCOUNT_MAGIC &&
-		    curr->magic != 0xffffffff) {
-			DLOG_ERR("Unexpected magic %08x at offset %08x; aborting.",
-				 curr->magic, i * bc_offset_increment);
+		if (curr->magic != BOOTCOUNT_MAGIC || curr->checksum != curr->magic + curr->count) {
+			DLOG_ERR("Unexpected boot-count log at offset %08x: magic %08x boot count %08x checksum %08x; aborting.",
+				 i * bc_offset_increment, curr->magic, curr->count, curr->checksum);
 
 			retval = -2;
 			goto out;
 		}
-
-		if (curr->magic == 0xffffffff)
-			break;
 
 		last_count = curr->count;
 	}
@@ -182,6 +179,7 @@ int mtd_resetbc(const char *mtd)
 	}
 
 out:
+	if (curr != NULL) free(curr);
 	close(fd);
 	return retval;
 }


### PR DESCRIPTION
1. Fix a bug that mtd cannot reset boot count when page size is larger than 2048
2. Add code to check the checksum in the boot-count log entry